### PR TITLE
Revert "Bump sphinx from 1.8.4 to 3.0.4" on master branch

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ watchdog==0.9.0
 flake8==3.7.7
 tox==3.7.0
 coverage==4.5.2
-Sphinx==3.0.4
+Sphinx==1.8.4
 twine==1.13.0
 
 pytest==4.3.0


### PR DESCRIPTION
Reverts jshprentz/meetup2xibo#2

Should have updated development. See jshprentz/meetup2xibo#16.